### PR TITLE
ci: add install script test workflow with multi-arch matrix

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,46 @@
+name: Test Install Script
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to test (e.g. v2.1.0)'
+        required: true
+        type: string
+        default: 'v2.1.0'
+
+jobs:
+  test:
+    name: Test (${{ matrix.arch }}) - ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install gh CLI (if missing)
+        run: |
+          if ! command -v gh &> /dev/null; then
+            echo "Installing gh CLI..."
+            type -p curl >/dev/null || sudo apt-get install -y curl
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update && sudo apt-get install -y gh
+          fi
+          gh --version
+
+      - name: Test install script
+        env:
+          CI: 'true'
+        run: |
+          set -x
+          echo "Testing install.sh on arch: ${{ matrix.arch }} with tag: ${{ inputs.tag }}"
+          curl -sSL https://github.com/clever-vpn/clever-vpn-server/raw/main/install.sh | bash -s -- "${{ inputs.tag }}"

--- a/install.sh
+++ b/install.sh
@@ -159,10 +159,14 @@ else
 fi
 
 echo "Running '$APP install'..."
-if [[ -n "$INSTALL_TOKEN" ]]; then
-    ./"$APP" install -token="$INSTALL_TOKEN"
+if [[ "${CI:-}" == "true" ]]; then
+    echo "CI environment detected, skipping service installation."
 else
-    ./"$APP" install
+    if [[ -n "$INSTALL_TOKEN" ]]; then
+        ./"$APP" install -token="$INSTALL_TOKEN"
+    else
+        ./"$APP" install
+    fi
 fi
 echo "Installation done."
 


### PR DESCRIPTION
## Summary

Add a manually-triggered CI workflow to test `install.sh` across architectures.

## Changes

### `.github/workflows/test-install.yml` (new)
- `workflow_dispatch` trigger with `tag` input (default: `v2.1.0`)
- Matrix strategy: `ubuntu-latest` (amd64) + `ubuntu-24.04-arm` (arm64)
- Auto-installs `gh` CLI if missing in runner
- Runs `curl | bash -s -- <tag>` with `CI=true`

### `install.sh`
- Add `CI` environment variable guard: when `CI=true`, skips `./clever-vpn-server install` but still performs download, decompress, and checksum verification