### PR TITLE
fix: pass GH_TOKEN to piped install script in CI

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Test install script
         env:
           CI: 'true'
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -x
           echo "Testing install.sh on arch: ${{ matrix.arch }} with tag: ${{ inputs.tag }}"


### PR DESCRIPTION
## Summary

Fix CI workflow failure: `gh` CLI inside `curl | bash` pipeline needs `GH_TOKEN` to authenticate.

## Root Cause
The `auto_upgrade_patch()` function in `install.sh` calls `gh release list`. When the script is executed via `curl | bash`, the `GH_TOKEN` environment variable is not inherited from the runner's auto-injected `GITHUB_TOKEN`.

## Fix
Added `GH_TOKEN: ${{ github.token }}` to the workflow step's `env` block.