### PR TITLE
fix: make auto_upgrade_patch resilient to API failures

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,12 +39,16 @@ auto_upgrade_patch() {
         local prefix="v${major}.${minor}."
         echo "Detected patch version $tag, searching for latest in $prefix* ..."
         # 通过 GitHub API 获取所有 tags，筛选 vX.Y.Z 格式，取最大 Z
+        # 临时关闭 pipefail：grep 无匹配时返回 1 不应中断脚本
         local latest
-        latest=$(curl -sSL "https://api.github.com/repos/$OWNER/$REPO/tags?per_page=100" \
+        set +o pipefail
+        latest=$(curl -sSL --connect-timeout 5 --max-time 10 \
+            "https://api.github.com/repos/$OWNER/$REPO/tags?per_page=100" 2>/dev/null \
             | grep -oE '"name": *"'"${prefix}[0-9]+"'"' \
             | grep -oE "${prefix}[0-9]+" \
-            | sort -t '.' -k3 -n \
+            | sort -t '.' -k3 -n 2>/dev/null \
             | tail -1)
+        set -o pipefail
         if [[ -n "$latest" ]]; then
             echo "Auto-upgraded to latest patch: $latest"
             echo "$latest"


### PR DESCRIPTION
## Summary

Fix CI exit code 3 by making the curl API pipeline tolerant to transient failures.

## Root Cause
With `set -euo pipefail`, when `grep` in the pipeline finds no match (API rate-limited, network issue, etc.), `pipefail` propagates exit code 1 and `set -e` kills the script.

## Fix
- Temporarily disable `pipefail` inside `auto_upgrade_patch()`
- Add `--connect-timeout 5 --max-time 10` to prevent hanging
- Suppress stderr from curl/sort for clean output
- Function gracefully falls back to original tag on any API error