### PR TITLE
fix: double-vv tag bug in Packer version normalization

### DIFF
--- a/packer/clever-vpn-server.pkr.hcl
+++ b/packer/clever-vpn-server.pkr.hcl
@@ -32,7 +32,7 @@ variable "droplet_size" {
 
 locals {
   # Normalize version: accept both "v2.1.6" and "2.1.6"
-  normalized_version = replace(var.version, "/^v/", "")
+  normalized_version = trimprefix(var.version, "v")
   tag                = "v${local.normalized_version}"
   snapshot_name      = "clever-vpn-server-${local.tag}"
 }


### PR DESCRIPTION
## Root Cause

HCL2 `replace()` does **literal** substring replacement, not regex. `replace(var.version, "/^v/", "")` was searching for the literal string `/^v/` — which never matched — so the leading `v` was never stripped.

This caused:
- `normalized_version` = `v2.1.6` (unchanged)
- `tag` = `vv2.1.6` (double v)
- Tag validation error: `invalid tag: version-vv2.1.6`

## Fix

Use `trimprefix(var.version, "v")` — the idiomatic HCL2 function for stripping a prefix.

```diff
- normalized_version = replace(var.version, "/^v/", "")
+ normalized_version = trimprefix(var.version, "v")
```